### PR TITLE
Update testHook API

### DIFF
--- a/out/api.d.ts
+++ b/out/api.d.ts
@@ -8,7 +8,7 @@ export declare enum Version {
     v1 = 1,
     v2 = 2,
     v3 = 3,
-    latest = 3,
+    latest = 3
 }
 /**
  * An interface to allow VS Code extensions to communicate with the C/C++ extension.

--- a/out/testApi.d.ts
+++ b/out/testApi.d.ts
@@ -27,9 +27,9 @@ export interface CppToolsTestApi extends CppToolsApi {
  */
 export interface CppToolsTestHook extends vscode.Disposable {
     /**
-     * Fires when the Tag Parser or IntelliSense engine's status changes.
+     * Fires when the status of Tag Parser or IntelliSense engine changes.
      */
-    readonly StatusChanged: vscode.Event<Status>;
+    readonly StatusChanged: vscode.Event<any>;
 }
 /**
  * Status codes.
@@ -38,6 +38,6 @@ export declare enum Status {
     TagParsingBegun = 1,
     TagParsingDone = 2,
     IntelliSenseCompiling = 3,
-    IntelliSenseReady = 4,
+    IntelliSenseReady = 4
 }
 export declare function getCppToolsTestApi(version: Version): Promise<CppToolsTestApi | undefined>;

--- a/out/testApi.d.ts
+++ b/out/testApi.d.ts
@@ -27,17 +27,24 @@ export interface CppToolsTestApi extends CppToolsApi {
  */
 export interface CppToolsTestHook extends vscode.Disposable {
     /**
-     * Fires when the status of Tag Parser or IntelliSense engine changes.
+     * Fires when the status of the Tag Parser or IntelliSense engine changes for an active document.
      */
-    readonly StatusChanged: vscode.Event<any>;
+    readonly StatusChanged: vscode.Event<IntelliSenseStatus>;
 }
 /**
- * Status codes.
+ * Tag Parser or IntelliSense status codes.
  */
 export declare enum Status {
     TagParsingBegun = 1,
     TagParsingDone = 2,
     IntelliSenseCompiling = 3,
     IntelliSenseReady = 4
+}
+/**
+ * Information about the status of Tag Parser or IntelliSense for an active document.
+ */
+export interface IntelliSenseStatus {
+    status: Status;
+    filename?: string;
 }
 export declare function getCppToolsTestApi(version: Version): Promise<CppToolsTestApi | undefined>;

--- a/out/testApi.d.ts
+++ b/out/testApi.d.ts
@@ -27,9 +27,13 @@ export interface CppToolsTestApi extends CppToolsApi {
  */
 export interface CppToolsTestHook extends vscode.Disposable {
     /**
+     * [Deprecated] Fires when the Tag Parser or IntelliSense engine's status changes.
+     */
+    readonly StatusChanged: vscode.Event<Status>;
+    /**
      * Fires when the status of the Tag Parser or IntelliSense engine changes for an active document.
      */
-    readonly StatusChanged: vscode.Event<IntelliSenseStatus>;
+    readonly IntelliSenseStatusChanged: vscode.Event<IntelliSenseStatus>;
 }
 /**
  * Tag Parser or IntelliSense status codes.

--- a/out/testApi.js
+++ b/out/testApi.js
@@ -15,7 +15,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const api_1 = require("./api");
 const vscode = require("vscode");
 /**
- * Status codes.
+ * Tag Parser or IntelliSense status codes.
  */
 var Status;
 (function (Status) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-cpptools",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -321,9 +321,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "requires": {
         "agent-base": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-cpptools",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Public API for vscode-cpptools",
   "typings": "./out/api.d.ts",
   "main": "./out/api.js",

--- a/testApi.ts
+++ b/testApi.ts
@@ -36,9 +36,9 @@ export interface CppToolsTestApi extends CppToolsApi {
  */
 export interface CppToolsTestHook extends vscode.Disposable {
     /**
-     * Fires when the Tag Parser or IntelliSense engine's status changes.
+     * Fires when the status of Tag Parser or IntelliSense engine changes.
      */
-    readonly StatusChanged: vscode.Event<Status>;
+    readonly StatusChanged: vscode.Event<any>;
 }
 
 /**

--- a/testApi.ts
+++ b/testApi.ts
@@ -36,9 +36,14 @@ export interface CppToolsTestApi extends CppToolsApi {
  */
 export interface CppToolsTestHook extends vscode.Disposable {
     /**
+     * [Deprecated] Fires when the Tag Parser or IntelliSense engine's status changes.
+     */
+    readonly StatusChanged: vscode.Event<Status>;
+
+    /**
      * Fires when the status of the Tag Parser or IntelliSense engine changes for an active document.
      */
-    readonly StatusChanged: vscode.Event<IntelliSenseStatus>;
+    readonly IntelliSenseStatusChanged: vscode.Event<IntelliSenseStatus>;
 }
 
 /**

--- a/testApi.ts
+++ b/testApi.ts
@@ -36,19 +36,27 @@ export interface CppToolsTestApi extends CppToolsApi {
  */
 export interface CppToolsTestHook extends vscode.Disposable {
     /**
-     * Fires when the status of Tag Parser or IntelliSense engine changes.
+     * Fires when the status of the Tag Parser or IntelliSense engine changes for an active document.
      */
-    readonly StatusChanged: vscode.Event<any>;
+    readonly StatusChanged: vscode.Event<IntelliSenseStatus>;
 }
 
 /**
- * Status codes.
+ * Tag Parser or IntelliSense status codes.
  */
 export enum Status {
     TagParsingBegun = 1,
     TagParsingDone = 2,
     IntelliSenseCompiling = 3,
     IntelliSenseReady = 4
+}
+
+/**
+ * Information about the status of Tag Parser or IntelliSense for an active document.
+ */
+export interface IntelliSenseStatus {
+    status: Status;
+    filename?: string;
 }
 
 function isCppToolsTestExtension(extension: CppToolsTestApi | CppToolsTestExtension): extension is CppToolsTestExtension {


### PR DESCRIPTION
- Deprecate test hook event StatusChanged.
- Add a test hook event called IntelliSenseStatusChanged that includes the name of the active document to the IntelliSense status.