### PR TITLE
Make intelliSenseMode optional.  Change c18/gnu18 to c17/gnu17

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -152,15 +152,15 @@ export interface SourceFileConfiguration {
     /**
      * The compiler to emulate.
      */
-    readonly intelliSenseMode: "msvc-x86" | "msvc-x64" | "msvc-arm" | "msvc-arm64" |
+    readonly intelliSenseMode?: "msvc-x86" | "msvc-x64" | "msvc-arm" | "msvc-arm64" |
         "gcc-x86" | "gcc-x64" | "gcc-arm" | "gcc-arm64" |
         "clang-x86" | "clang-x64" | "clang-arm" | "clang-arm64";
 
     /**
      * The C or C++ standard to emulate.
      */
-    readonly standard: "c89" | "c99" | "c11" | "c18" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" |
-        "gnu89" | "gnu99" | "gnu11" | "gnu18" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20";
+    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" |
+        "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20";
     /**
      * Any files that need to be included before the source file is parsed.
      */
@@ -234,8 +234,8 @@ export interface WorkspaceBrowseConfiguration {
      * The C or C++ standard to emulate. This field defaults to "c++17" and will only be used if
      * [compilerPath](#WorkspaceBrowseConfiguration.compilerPath) is set.
      */
-    readonly standard?: "c89" | "c99" | "c11" | "c18" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" |
-        "gnu89" | "gnu99" | "gnu11" | "gnu18" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20";
+    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" |
+        "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20";
     /**
      * The version of the Windows SDK that should be used. This field defaults to the latest Windows SDK
      * installed on the PC and will only be used if [compilerPath](#WorkspaceBrowseConfiguration.compilerPath)

--- a/out/api.d.ts
+++ b/out/api.d.ts
@@ -129,11 +129,11 @@ export interface SourceFileConfiguration {
     /**
      * The compiler to emulate.
      */
-    readonly intelliSenseMode: "msvc-x86" | "msvc-x64" | "msvc-arm" | "msvc-arm64" | "gcc-x86" | "gcc-x64" | "gcc-arm" | "gcc-arm64" | "clang-x86" | "clang-x64" | "clang-arm" | "clang-arm64";
+    readonly intelliSenseMode?: "msvc-x86" | "msvc-x64" | "msvc-arm" | "msvc-arm64" | "gcc-x86" | "gcc-x64" | "gcc-arm" | "gcc-arm64" | "clang-x86" | "clang-x64" | "clang-arm" | "clang-arm64";
     /**
      * The C or C++ standard to emulate.
      */
-    readonly standard: "c89" | "c99" | "c11" | "c18" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "gnu89" | "gnu99" | "gnu11" | "gnu18" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20";
+    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20";
     /**
      * Any files that need to be included before the source file is parsed.
      */
@@ -198,7 +198,7 @@ export interface WorkspaceBrowseConfiguration {
      * The C or C++ standard to emulate. This field defaults to "c++17" and will only be used if
      * [compilerPath](#WorkspaceBrowseConfiguration.compilerPath) is set.
      */
-    readonly standard?: "c89" | "c99" | "c11" | "c18" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "gnu89" | "gnu99" | "gnu11" | "gnu18" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20";
+    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20";
     /**
      * The version of the Windows SDK that should be used. This field defaults to the latest Windows SDK
      * installed on the PC and will only be used if [compilerPath](#WorkspaceBrowseConfiguration.compilerPath)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-cpptools",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-cpptools",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Public API for vscode-cpptools",
   "typings": "./out/api.d.ts",
   "main": "./out/api.js",


### PR DESCRIPTION
This corresponds with: https://github.com/microsoft/vscode-cpptools/pull/6180

This change should be backwards compatible.  We will still process c18/gnu18.  IntelliSenseMode is being made optional, but existing code would specify a value.

Also made standard version optional, as it could be inferred from a compilerPath if not specified.