### PR TITLE
Add new IntelliSense modes to support cross compilation configuration

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -15,7 +15,8 @@ export enum Version {
     v2 = 2, // 2.x.x
     v3 = 3, // 3.x.x
     v4 = 4, // 4.x.x
-    latest = v4
+    v5 = 5, // 5.x.x
+    latest = v5
 }
 
 /**
@@ -154,6 +155,9 @@ export interface SourceFileConfiguration {
 
     /**
      * The platform, compiler, and architecture variant to emulate.
+     * IntelliSenseMode values without a platform variant will resolve to a value that matches
+     * the host platform. For example, if the host platform is Windows and the IntelliSenseMode
+     * is "clang-x64", then "clang-x64" will resolve to "windows-clang-x64".
      */
     readonly intelliSenseMode?: "linux-clang-x86" | "linux-clang-x64" | "linux-clang-arm" | "linux-clang-arm64" |
         "linux-gcc-x86" | "linux-gcc-x64" | "linux-gcc-arm" | "linux-gcc-arm64" |

--- a/api.ts
+++ b/api.ts
@@ -153,9 +153,16 @@ export interface SourceFileConfiguration {
     readonly defines: string[];
 
     /**
-     * The compiler to emulate.
+     * The platform, compiler, and architecture variant to emulate.
      */
-    readonly intelliSenseMode?: "msvc-x86" | "msvc-x64" | "msvc-arm" | "msvc-arm64" |
+    readonly intelliSenseMode?: "linux-clang-x86" | "linux-clang-x64" | "linux-clang-arm" | "linux-clang-arm64" |
+        "linux-gcc-x86" | "linux-gcc-x64" | "linux-gcc-arm" | "linux-gcc-arm64" |
+        "macos-clang-x86" | "macos-clang-x64" | "macos-clang-arm" | "macos-clang-arm64" |
+        "macos-gcc-x86" | "macos-gcc-x64" | "macos-gcc-arm" | "macos-gcc-arm64" |
+        "windows-clang-x86" | "windows-clang-x64" | "windows-clang-arm" | "windows-clang-arm64" |
+        "windows-gcc-x86" | "windows-gcc-x64" | "windows-gcc-arm" | "windows-gcc-arm64" |
+        "windows-msvc-x86" | "windows-msvc-x64" | "windows-msvc-arm" | "windows-msvc-arm64" |
+        "msvc-x86" | "msvc-x64" | "msvc-arm" | "msvc-arm64" |
         "gcc-x86" | "gcc-x64" | "gcc-arm" | "gcc-arm64" |
         "clang-x86" | "clang-x64" | "clang-arm" | "clang-arm64";
 

--- a/out/api.d.ts
+++ b/out/api.d.ts
@@ -8,7 +8,8 @@ export declare enum Version {
     v2 = 2,
     v3 = 3,
     v4 = 4,
-    latest = 4
+    v5 = 5,
+    latest = 5
 }
 /**
  * An interface to allow VS Code extensions to communicate with the C/C++ extension.
@@ -131,6 +132,9 @@ export interface SourceFileConfiguration {
     readonly defines: string[];
     /**
      * The platform, compiler, and architecture variant to emulate.
+     * IntelliSenseMode values without a platform variant will resolve to a value that matches
+     * the host platform. For example, if the host platform is Windows and the IntelliSenseMode
+     * is "clang-x64", then "clang-x64" will resolve to "windows-clang-x64".
      */
     readonly intelliSenseMode?: "linux-clang-x86" | "linux-clang-x64" | "linux-clang-arm" | "linux-clang-arm64" | "linux-gcc-x86" | "linux-gcc-x64" | "linux-gcc-arm" | "linux-gcc-arm64" | "macos-clang-x86" | "macos-clang-x64" | "macos-clang-arm" | "macos-clang-arm64" | "macos-gcc-x86" | "macos-gcc-x64" | "macos-gcc-arm" | "macos-gcc-arm64" | "windows-clang-x86" | "windows-clang-x64" | "windows-clang-arm" | "windows-clang-arm64" | "windows-gcc-x86" | "windows-gcc-x64" | "windows-gcc-arm" | "windows-gcc-arm64" | "windows-msvc-x86" | "windows-msvc-x64" | "windows-msvc-arm" | "windows-msvc-arm64" | "msvc-x86" | "msvc-x64" | "msvc-arm" | "msvc-arm64" | "gcc-x86" | "gcc-x64" | "gcc-arm" | "gcc-arm64" | "clang-x86" | "clang-x64" | "clang-arm" | "clang-arm64";
     /**

--- a/out/api.d.ts
+++ b/out/api.d.ts
@@ -130,9 +130,9 @@ export interface SourceFileConfiguration {
      */
     readonly defines: string[];
     /**
-     * The compiler to emulate.
+     * The platform, compiler, and architecture variant to emulate.
      */
-    readonly intelliSenseMode?: "msvc-x86" | "msvc-x64" | "msvc-arm" | "msvc-arm64" | "gcc-x86" | "gcc-x64" | "gcc-arm" | "gcc-arm64" | "clang-x86" | "clang-x64" | "clang-arm" | "clang-arm64";
+    readonly intelliSenseMode?: "linux-clang-x86" | "linux-clang-x64" | "linux-clang-arm" | "linux-clang-arm64" | "linux-gcc-x86" | "linux-gcc-x64" | "linux-gcc-arm" | "linux-gcc-arm64" | "macos-clang-x86" | "macos-clang-x64" | "macos-clang-arm" | "macos-clang-arm64" | "macos-gcc-x86" | "macos-gcc-x64" | "macos-gcc-arm" | "macos-gcc-arm64" | "windows-clang-x86" | "windows-clang-x64" | "windows-clang-arm" | "windows-clang-arm64" | "windows-gcc-x86" | "windows-gcc-x64" | "windows-gcc-arm" | "windows-gcc-arm64" | "windows-msvc-x86" | "windows-msvc-x64" | "windows-msvc-arm" | "windows-msvc-arm64" | "msvc-x86" | "msvc-x64" | "msvc-arm" | "msvc-arm64" | "gcc-x86" | "gcc-x64" | "gcc-arm" | "gcc-arm64" | "clang-x86" | "clang-x64" | "clang-arm" | "clang-arm64";
     /**
      * The C or C++ standard to emulate.
      */

--- a/out/api.js
+++ b/out/api.js
@@ -25,7 +25,8 @@ var Version;
     Version[Version["v2"] = 2] = "v2";
     Version[Version["v3"] = 3] = "v3";
     Version[Version["v4"] = 4] = "v4";
-    Version[Version["latest"] = 4] = "latest";
+    Version[Version["v5"] = 5] = "v5";
+    Version[Version["latest"] = 5] = "latest";
 })(Version = exports.Version || (exports.Version = {}));
 /**
  * Check if an object satisfies the contract of the CppToolsExtension interface.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-cpptools",
-  "version": "4.0.3",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-cpptools",
-  "version": "4.0.3",
+  "version": "5.0.0",
   "description": "Public API for vscode-cpptools",
   "typings": "./out/api.d.ts",
   "main": "./out/api.js",


### PR DESCRIPTION
- Update API version to 5.0.0
- Add 28 new IntelliSense modes

This supports https://github.com/microsoft/vscode-cpptools/pull/6745