### PR TITLE
Update node and package-lock.json.

### DIFF
--- a/jobs/cg.yml
+++ b/jobs/cg.yml
@@ -56,9 +56,9 @@ extends:
         - checkout: self
 
         - task: UseNode@1
-          displayName: Use Node 18.x
+          displayName: Use Node 22.x
           inputs:
-            version: 18.x
+            version: 22.x
 
         - task: Npm@1
           displayName: 'npm install'

--- a/jobs/cg.yml
+++ b/jobs/cg.yml
@@ -60,6 +60,9 @@ extends:
           inputs:
             version: 22.x
 
+        - script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
+          displayName: Delete .npmrc if it exists
+
         - task: Npm@1
           displayName: 'npm install'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-cpptools",
   "version": "6.2.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -18,22 +18,23 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "14.14.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.16.tgz",
-      "integrity": "sha512-naXYePhweTi+BMv11TgioE2/FXU4fSl29HAH1ffxVciNsH3rYXjNP2yM8wqmSm7jS20gM8TIklKiTen+1iVncw==",
-      "dev": true
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
       "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -41,26 +42,6 @@
       "engines": {
         "node": ">=4.2.0"
       }
-    }
-  },
-  "dependencies": {
-    "@types/node": {
-      "version": "14.14.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.16.tgz",
-      "integrity": "sha512-naXYePhweTi+BMv11TgioE2/FXU4fSl29HAH1ffxVciNsH3rYXjNP2yM8wqmSm7jS20gM8TIklKiTen+1iVncw==",
-      "dev": true
-    },
-    "@types/vscode": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
-      "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
-      "dev": true
-    },
-    "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
-      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,20 +19,22 @@
     },
     "node_modules/@types/node": {
       "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha1-F4j6jag427X56plLg0J4IF22yis=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
-      "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
+      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/@types/vscode/-/vscode-1.52.0.tgz",
+      "integrity": "sha1-YZF5aN1AOTISf8QASiH9jWnk9hw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "4.1.3",
+      "version": "4.9.5",
+      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha1-CVl5+bzA0J2jJNWNA86Pg3TL5lo=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
Fixes the `npm install` failiure when running vscode-cpptools-api CG.

Follow up to https://github.com/microsoft/vscode-cpptools-api/pull/58 and https://github.com/microsoft/vscode-cpptools/pull/13454/files
