### PR TITLE
Normalize repo url.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/vscode-cpptools-api.git"
+    "url": "git+https://github.com/Microsoft/vscode-cpptools-api.git"
   },
   "bugs": {
     "url": "https://github.com/Microsoft/vscode-cpptools-api/issues"


### PR DESCRIPTION
Fix the npm warning:

![image](https://github.com/user-attachments/assets/8e6179ef-c82f-495e-bfba-998a97f14f3d)
