### PR TITLE
Add a v7 to the Version to allow checking for cpp26 support.

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -17,7 +17,8 @@ export enum Version {
     v4 = 4, // 4.x.x
     v5 = 5, // 5.x.x
     v6 = 6, // 6.x.x
-    latest = v6
+    v7 = 7, // 7.x.x
+    latest = v7
 }
 
 /**

--- a/out/api.d.ts
+++ b/out/api.d.ts
@@ -10,7 +10,8 @@ export declare enum Version {
     v4 = 4,
     v5 = 5,
     v6 = 6,
-    latest = 6
+    v7 = 7,
+    latest = 7
 }
 /**
  * An interface to allow VS Code extensions to communicate with the C/C++ extension.

--- a/out/api.js
+++ b/out/api.js
@@ -27,7 +27,8 @@ var Version;
     Version[Version["v4"] = 4] = "v4";
     Version[Version["v5"] = 5] = "v5";
     Version[Version["v6"] = 6] = "v6";
-    Version[Version["latest"] = 6] = "latest";
+    Version[Version["v7"] = 7] = "v7";
+    Version[Version["latest"] = 7] = "latest";
 })(Version = exports.Version || (exports.Version = {}));
 /**
  * Check if an object satisfies the contract of the CppToolsExtension interface.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-cpptools",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-cpptools",
-      "version": "6.3.0",
+      "version": "7.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^14.14.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-cpptools",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "description": "Public API for vscode-cpptools",
   "typings": "./out/api.d.ts",
   "main": "./out/api.js",


### PR DESCRIPTION
The previous PR https://github.com/microsoft/vscode-cpptools-api/pull/60 that added cpp26-related support and increased the version to 6.3 didn't add a new Version in the API for proper version checking, e.g. CMake Tools needs to check for v7 to prevent sending unsupported cppStandard to older versions of the C/C++ extension without cpp26-support.