### PR TITLE
Undo unnecessary standard changes.

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -17,8 +17,7 @@ export enum Version {
     v4 = 4, // 4.x.x
     v5 = 5, // 5.x.x
     v6 = 6, // 6.x.x
-    v7 = 7, // 7.x.x
-    latest = v7
+    latest = v6
 }
 
 /**
@@ -175,8 +174,8 @@ export interface SourceFileConfiguration {
     /**
      * The C or C++ standard to emulate.
      */
-    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "c++23" | "c++26" |
-        "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20" | "gnu++23" | "gnu++26";
+    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" |
+        "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20";
     /**
      * Any files that need to be included before the source file is parsed.
      */
@@ -264,8 +263,8 @@ export interface WorkspaceBrowseConfiguration {
      * The C or C++ standard to emulate. This field defaults to "c++17" and will only be used if
      * [compilerPath](#WorkspaceBrowseConfiguration.compilerPath) is set.
      */
-    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "c++23" | "c++26" |
-        "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20" | "gnu++23" | "gnu++26";
+    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" |
+        "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20";
     /**
      * The version of the Windows SDK that should be used. This field defaults to the latest Windows SDK
      * installed on the PC and will only be used if [compilerPath](#WorkspaceBrowseConfiguration.compilerPath)

--- a/out/api.d.ts
+++ b/out/api.d.ts
@@ -10,8 +10,7 @@ export declare enum Version {
     v4 = 4,
     v5 = 5,
     v6 = 6,
-    v7 = 7,
-    latest = 7
+    latest = 6
 }
 /**
  * An interface to allow VS Code extensions to communicate with the C/C++ extension.
@@ -142,7 +141,7 @@ export interface SourceFileConfiguration {
     /**
      * The C or C++ standard to emulate.
      */
-    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "c++23" | "c++26" | "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20" | "gnu++23" | "gnu++26";
+    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20";
     /**
      * Any files that need to be included before the source file is parsed.
      */
@@ -219,7 +218,7 @@ export interface WorkspaceBrowseConfiguration {
      * The C or C++ standard to emulate. This field defaults to "c++17" and will only be used if
      * [compilerPath](#WorkspaceBrowseConfiguration.compilerPath) is set.
      */
-    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "c++23" | "c++26" | "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20" | "gnu++23" | "gnu++26";
+    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20";
     /**
      * The version of the Windows SDK that should be used. This field defaults to the latest Windows SDK
      * installed on the PC and will only be used if [compilerPath](#WorkspaceBrowseConfiguration.compilerPath)

--- a/out/api.js
+++ b/out/api.js
@@ -27,8 +27,7 @@ var Version;
     Version[Version["v4"] = 4] = "v4";
     Version[Version["v5"] = 5] = "v5";
     Version[Version["v6"] = 6] = "v6";
-    Version[Version["v7"] = 7] = "v7";
-    Version[Version["latest"] = 7] = "latest";
+    Version[Version["latest"] = 6] = "latest";
 })(Version = exports.Version || (exports.Version = {}));
 /**
  * Check if an object satisfies the contract of the CppToolsExtension interface.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-cpptools",
-  "version": "7.0.3",
+  "version": "6.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-cpptools",
-      "version": "7.0.3",
+      "version": "6.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^14.14.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-cpptools",
-  "version": "7.0.3",
+  "version": "6.4.0",
   "description": "Public API for vscode-cpptools",
   "typings": "./out/api.d.ts",
   "main": "./out/api.js",


### PR DESCRIPTION
The versions >=6 don't use the standard version so there was no need to update it for version 6/7.