### PR TITLE
Refactor standard type

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -22,8 +22,8 @@ export enum Version {
 }
 
 export type CStandard = "c89" | "c99" | "c11" | "c17" | "c23";
-export type CppStandard = "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "c++23" | "c++26";
 export type GnuCStandard = "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu23";
+export type CppStandard = "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "c++23" | "c++26";
 export type GnuCppStandard = "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20" | "gnu++23" | "gnu++26";
 
 /**
@@ -180,7 +180,7 @@ export interface SourceFileConfiguration {
     /**
      * The C or C++ standard to emulate.
      */
-    readonly standard?: CStandard | CppStandard | GnuCStandard | GnuCppStandard;
+    readonly standard?: CStandard | GnuCStandard | CppStandard | GnuCppStandard;
     /**
      * Any files that need to be included before the source file is parsed.
      */
@@ -268,7 +268,7 @@ export interface WorkspaceBrowseConfiguration {
      * The C or C++ standard to emulate. This field defaults to "c++17" and will only be used if
      * [compilerPath](#WorkspaceBrowseConfiguration.compilerPath) is set.
      */
-    readonly standard?: CStandard | CppStandard | GnuCStandard | GnuCppStandard;
+    readonly standard?: CStandard | GnuCStandard | CppStandard | GnuCppStandard;
     /**
      * The version of the Windows SDK that should be used. This field defaults to the latest Windows SDK
      * installed on the PC and will only be used if [compilerPath](#WorkspaceBrowseConfiguration.compilerPath)

--- a/api.ts
+++ b/api.ts
@@ -21,6 +21,11 @@ export enum Version {
     latest = v7
 }
 
+export type CStandard = "c89" | "c99" | "c11" | "c17" | "c23";
+export type CppStandard = "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "c++23" | "c++26";
+export type GnuCStandard = "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu23";
+export type GnuCppStandard = "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20" | "gnu++23" | "gnu++26";
+
 /**
  * An interface to allow VS Code extensions to communicate with the C/C++ extension.
  * @see [CppToolsExtension](#CppToolsExtension) for a code example.
@@ -175,8 +180,7 @@ export interface SourceFileConfiguration {
     /**
      * The C or C++ standard to emulate.
      */
-    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c23" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "c++23" | "c++26" |
-        "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu23" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20" | "gnu++23" | "gnu++26";
+    readonly standard?: CStandard | CppStandard | GnuCStandard | GnuCppStandard;
     /**
      * Any files that need to be included before the source file is parsed.
      */
@@ -264,8 +268,7 @@ export interface WorkspaceBrowseConfiguration {
      * The C or C++ standard to emulate. This field defaults to "c++17" and will only be used if
      * [compilerPath](#WorkspaceBrowseConfiguration.compilerPath) is set.
      */
-    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c23" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "c++23" | "c++26" |
-        "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu23" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20" | "gnu++23" | "gnu++26";
+    readonly standard?: CStandard | CppStandard | GnuCStandard | GnuCppStandard;
     /**
      * The version of the Windows SDK that should be used. This field defaults to the latest Windows SDK
      * installed on the PC and will only be used if [compilerPath](#WorkspaceBrowseConfiguration.compilerPath)

--- a/out/api.d.ts
+++ b/out/api.d.ts
@@ -14,8 +14,8 @@ export declare enum Version {
     latest = 7
 }
 export type CStandard = "c89" | "c99" | "c11" | "c17" | "c23";
-export type CppStandard = "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "c++23" | "c++26";
 export type GnuCStandard = "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu23";
+export type CppStandard = "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "c++23" | "c++26";
 export type GnuCppStandard = "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20" | "gnu++23" | "gnu++26";
 /**
  * An interface to allow VS Code extensions to communicate with the C/C++ extension.
@@ -146,7 +146,7 @@ export interface SourceFileConfiguration {
     /**
      * The C or C++ standard to emulate.
      */
-    readonly standard?: CStandard | CppStandard | GnuCStandard | GnuCppStandard;
+    readonly standard?: CStandard | GnuCStandard | CppStandard | GnuCppStandard;
     /**
      * Any files that need to be included before the source file is parsed.
      */
@@ -223,7 +223,7 @@ export interface WorkspaceBrowseConfiguration {
      * The C or C++ standard to emulate. This field defaults to "c++17" and will only be used if
      * [compilerPath](#WorkspaceBrowseConfiguration.compilerPath) is set.
      */
-    readonly standard?: CStandard | CppStandard | GnuCStandard | GnuCppStandard;
+    readonly standard?: CStandard | GnuCStandard | CppStandard | GnuCppStandard;
     /**
      * The version of the Windows SDK that should be used. This field defaults to the latest Windows SDK
      * installed on the PC and will only be used if [compilerPath](#WorkspaceBrowseConfiguration.compilerPath)

--- a/out/api.d.ts
+++ b/out/api.d.ts
@@ -13,6 +13,10 @@ export declare enum Version {
     v7 = 7,
     latest = 7
 }
+export type CStandard = "c89" | "c99" | "c11" | "c17" | "c23";
+export type CppStandard = "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "c++23" | "c++26";
+export type GnuCStandard = "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu23";
+export type GnuCppStandard = "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20" | "gnu++23" | "gnu++26";
 /**
  * An interface to allow VS Code extensions to communicate with the C/C++ extension.
  * @see [CppToolsExtension](#CppToolsExtension) for a code example.
@@ -142,7 +146,7 @@ export interface SourceFileConfiguration {
     /**
      * The C or C++ standard to emulate.
      */
-    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c23" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "c++23" | "c++26" | "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu23" | "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20" | "gnu++23" | "gnu++26";
+    readonly standard?: CStandard | CppStandard | GnuCStandard | GnuCppStandard;
     /**
      * Any files that need to be included before the source file is parsed.
      */
@@ -219,7 +223,7 @@ export interface WorkspaceBrowseConfiguration {
      * The C or C++ standard to emulate. This field defaults to "c++17" and will only be used if
      * [compilerPath](#WorkspaceBrowseConfiguration.compilerPath) is set.
      */
-    readonly standard?: "c89" | "c99" | "c11" | "c17" | "c23" | "c++98" | "c++03" | "c++11" | "c++14" | "c++17" | "c++20" | "c++23" | "c++26" | "gnu89" | "gnu99" | "gnu11" | "gnu17" | "gnu23"| "gnu++98" | "gnu++03" | "gnu++11" | "gnu++14" | "gnu++17" | "gnu++20" | "gnu++23" | "gnu++26";
+    readonly standard?: CStandard | CppStandard | GnuCStandard | GnuCppStandard;
     /**
      * The version of the Windows SDK that should be used. This field defaults to the latest Windows SDK
      * installed on the PC and will only be used if [compilerPath](#WorkspaceBrowseConfiguration.compilerPath)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-cpptools",
-  "version": "7.0.4",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-cpptools",
-      "version": "7.0.4",
+      "version": "7.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^14.14.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-cpptools",
-  "version": "7.0.4",
+  "version": "7.1.0",
   "description": "Public API for vscode-cpptools",
   "typings": "./out/api.d.ts",
   "main": "./out/api.js",


### PR DESCRIPTION
It's error prone to have two copies of this list in the API (e.g. #66). Refactoring it into its own type.